### PR TITLE
Searches are no longer duplicated & NFC Error Checking

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "gt.hack.nfc"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 6
-        versionName "2.1.1"
+        versionCode 7
+        versionName "2.2.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,12 +27,6 @@ android {
     buildToolsVersion = '28.0.3'
 }
 
-kotlin {
-    experimental {
-        coroutines 'enable'
-    }
-}
-
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.google.code.gson:gson:2.8.5'
@@ -42,14 +36,14 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support:cardview-v7:28.0.0'
     implementation 'com.android.support:design:28.0.0'
-    implementation 'com.google.android.gms:play-services-vision:16.2.0'
+    implementation 'com.google.android.gms:play-services-vision:17.0.2'
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
     implementation 'com.mikepenz:google-material-typeface:3.0.1.1.original@aar'
     implementation 'com.android.support:support-v4:28.0.0'
     implementation 'junit:junit:4.12'
     implementation 'com.apollographql.apollo:apollo-runtime:1.0.0-alpha2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.21'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.1'
 }
 
 configurations.all {

--- a/app/src/main/java/gt/hack/nfc/MainActivity.java
+++ b/app/src/main/java/gt/hack/nfc/MainActivity.java
@@ -115,7 +115,7 @@ public class MainActivity extends AppCompatActivity {
 
         //TODO: implement server-side access control
         if (username.equals("ehsan") || username.equals("petschekr") || username.equals("julian") || username.equals("kexin")
-                || username.equals("evan")) {
+                || username.equals("evan") || username.equals("nickg")) {
             drawerItems.add(DrawerItem.SEARCH.getDrawerItem().withIdentifier(101));
         }
         drawerItems.add(DrawerItem.TAP.getDrawerItem().withIdentifier(102));

--- a/app/src/main/java/gt/hack/nfc/fragment/CheckinFlowFragment.java
+++ b/app/src/main/java/gt/hack/nfc/fragment/CheckinFlowFragment.java
@@ -86,7 +86,7 @@ public class CheckinFlowFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        final ProgressBar progressBar = getActivity().findViewById(R.id.waitForBadge);
+        final ProgressBar progressBar = getActivity().findViewById(R.id.wait_for_badge_tap);
 
         TextView nameView = getActivity().findViewById(R.id.hacker_checkin_name);
         nameView.setText(name);

--- a/app/src/main/java/gt/hack/nfc/fragment/CheckinFragment.kt
+++ b/app/src/main/java/gt/hack/nfc/fragment/CheckinFragment.kt
@@ -12,6 +12,7 @@ import android.media.ToneGenerator
 import android.os.AsyncTask
 import android.os.Bundle
 import android.preference.PreferenceManager
+import android.provider.Settings
 import android.support.v4.app.ActivityCompat
 import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentManager
@@ -20,7 +21,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
+import android.widget.*
 
 import com.apollographql.apollo.exception.ApolloException
 import com.google.android.gms.common.ConnectionResult
@@ -37,6 +38,7 @@ import gt.hack.nfc.R
 import gt.hack.nfc.UserGetQuery
 import gt.hack.nfc.util.API
 import gt.hack.nfc.util.CameraSourcePreview
+import gt.hack.nfc.util.NFCHandler
 import kotlinx.coroutines.runBlocking
 
 class CheckinFragment : Fragment() {
@@ -44,6 +46,7 @@ class CheckinFragment : Fragment() {
     private var mCameraSource: CameraSource? = null
     private var mPreview: CameraSourcePreview? = null
     private var foundTag: Boolean = false
+    private var nfcHandler = NFCHandler()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -65,6 +68,10 @@ class CheckinFragment : Fragment() {
                               savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)
         return inflater.inflate(R.layout.fragment_checkin, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
     }
 
     /**

--- a/app/src/main/java/gt/hack/nfc/fragment/CheckinFragment.kt
+++ b/app/src/main/java/gt/hack/nfc/fragment/CheckinFragment.kt
@@ -37,7 +37,7 @@ import gt.hack.nfc.R
 import gt.hack.nfc.UserGetQuery
 import gt.hack.nfc.util.API
 import gt.hack.nfc.util.CameraSourcePreview
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 
 class CheckinFragment : Fragment() {
 

--- a/app/src/main/java/gt/hack/nfc/fragment/SearchFragment.kt
+++ b/app/src/main/java/gt/hack/nfc/fragment/SearchFragment.kt
@@ -91,7 +91,7 @@ class SearchFragment : ListFragment(), SearchView.OnQueryTextListener {
             setListShown(true)
             if (searchResults != null) {
                 adapter!!.clear()
-                adapter!!.addAll(searchResults)
+                adapter!!.addAll(HashSet(searchResults))
                 (listAdapter as SearchAdapter).notifyDataSetChanged()
             }
         }

--- a/app/src/main/java/gt/hack/nfc/fragment/SearchFragment.kt
+++ b/app/src/main/java/gt/hack/nfc/fragment/SearchFragment.kt
@@ -16,7 +16,6 @@ import android.view.View
 import android.widget.ListView
 
 import com.apollographql.apollo.exception.ApolloException
-import kotlin.coroutines.experimental.*;
 
 import java.util.ArrayList
 
@@ -24,8 +23,7 @@ import java.util.ArrayList
 import gt.hack.nfc.R
 import gt.hack.nfc.util.API
 import gt.hack.nfc.util.SearchAdapter
-import kotlinx.coroutines.experimental.launch
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 
 class SearchFragment : ListFragment(), SearchView.OnQueryTextListener {
     private var adapter: SearchAdapter? = null

--- a/app/src/main/java/gt/hack/nfc/fragment/TapFragment.kt
+++ b/app/src/main/java/gt/hack/nfc/fragment/TapFragment.kt
@@ -4,6 +4,7 @@ import java.util.*
 
 import android.app.AlertDialog
 import android.content.DialogInterface.OnClickListener
+import android.content.Intent
 import android.media.AudioManager
 import android.media.ToneGenerator
 import android.net.Uri
@@ -16,6 +17,7 @@ import android.os.Bundle
 import android.os.Handler
 
 import android.preference.PreferenceManager
+import android.provider.Settings
 import android.support.v4.app.Fragment
 import android.util.Log
 import android.view.LayoutInflater
@@ -103,6 +105,17 @@ class TapFragment : Fragment() {
       // if device does not support NFC provide dialog instead of just crashing
       showAlert("This device does not support NFC.", "Badges cannot be read or written using this device.")
       return
+    }
+
+    // Show alert if NFC is disabled
+    if (!nfc.isEnabled) {
+      val dialog = android.support.v7.app.AlertDialog.Builder(activity!!)
+      dialog.setTitle("NFC Disabled!")
+      dialog.setMessage("Badge scanning is unlikely to work w/o NFC. Would you like to enable NFC?")
+      dialog.setPositiveButton("Enable NFC") { _, _ -> startActivity(Intent(Settings.ACTION_NFC_SETTINGS)) }
+      dialog.setNegativeButton("Cancel", null)
+      dialog.show()
+      return 
     }
 
     nfc.enableReaderMode(activity, { tag: Tag ->

--- a/app/src/main/java/gt/hack/nfc/fragment/TapFragment.kt
+++ b/app/src/main/java/gt/hack/nfc/fragment/TapFragment.kt
@@ -99,6 +99,12 @@ class TapFragment : Fragment() {
 
     val nfc = NfcAdapter.getDefaultAdapter(activity)
 
+    if (nfc == null) {
+      // if device does not support NFC provide dialog instead of just crashing
+      showAlert("This device does not support NFC.", "Badges cannot be read or written using this device.")
+      return
+    }
+
     nfc.enableReaderMode(activity, { tag: Tag ->
       if (waitingForTag) {
         waitingForTag = false
@@ -260,8 +266,9 @@ class TapFragment : Fragment() {
     }
   }
 
-  fun showAlert(title: String, message: Int) {
+  fun showAlert(title: String, message: CharSequence) {
     val builder: AlertDialog.Builder
+
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       builder = AlertDialog.Builder(context, android.R.style.Theme_Material_Dialog_Alert)
     } else {

--- a/app/src/main/java/gt/hack/nfc/fragment/TapFragment.kt
+++ b/app/src/main/java/gt/hack/nfc/fragment/TapFragment.kt
@@ -2,9 +2,6 @@ package gt.hack.nfc.fragment
 
 import java.util.*
 
-import android.app.AlertDialog
-import android.content.DialogInterface
-import android.content.DialogInterface.OnClickListener
 import android.content.Intent
 import android.media.AudioManager
 import android.media.ToneGenerator
@@ -13,7 +10,6 @@ import android.nfc.NdefRecord
 import android.nfc.tech.Ndef
 import android.nfc.NfcAdapter
 import android.nfc.Tag
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 
@@ -27,308 +23,259 @@ import android.view.ViewGroup
 import android.widget.*
 import gt.hack.nfc.R
 import gt.hack.nfc.util.API
+import gt.hack.nfc.util.NFCHandler
 import gt.hack.nfc.util.Util
 
 import kotlinx.android.synthetic.main.fragment_tap.*
 import kotlinx.coroutines.runBlocking
 import kotlin.collections.ArrayList
 
-class TapFragment : Fragment(), View.OnClickListener {
+class TapFragment : Fragment() {
 
-  val READER_FLAGS = NfcAdapter.FLAG_READER_NFC_A
-  val TAG = "CHECKIN/TAP_FRAGMENT"
-  var waitingForTag = true
-  var nfcIsLoaded = false
+    val TAG = "CHECKIN/TAP_FRAGMENT"
+    var waitingForTag = true
+    private var nfcHandler = NFCHandler()
 
-  companion object {
-    fun newInstance(): TapFragment {
-      return TapFragment()
-    }
-  }
-
-  override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-    return inflater.inflate(R.layout.fragment_tap, container, false)
-  }
-
-  override fun onResume() {
-    super.onResume()
-
-    // in case NFC becomes enabled in settings
-    if (view != null) {
-      loadNFC(view!!)
-    }
-  }
-
-  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-    super.onViewCreated(view, savedInstanceState)
-    val uuidRegex = Regex("[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}")
-    Log.i("checkin-tap", "inside onviewcreated")
-    val tagSelect: AutoCompleteTextView = checkin_tag
-    val prevTag = tagSelect.text
-    tagSelect.setText("Updating tags list...")
-    tagSelect.isEnabled = false
-
-    val preferences = PreferenceManager.getDefaultSharedPreferences(activity)
-    var error = false
-    var allTags = runBlocking { API.getTags(preferences) } // TODO: this seems to delay showing this screen, so check that out
-    val currentCheckinTags = runBlocking { API.getTags(preferences, true) }
-
-    allTags = allTags as ArrayList<String>
-    allTags.sortWith(kotlin.Comparator { t1, t2 ->
-      val t1SortVal = when (currentCheckinTags?.contains(t1)) {
-        true -> -1
-        else -> 0
-      }
-      val t2SortVal = when (currentCheckinTags?.contains(t2)) {
-        true -> -1
-        else -> 0
-      }
-      t1SortVal - t2SortVal
-    })
-    Log.i(TAG, "Contents of sorted allTags: " + allTags)
-
-    tagSelect.text = prevTag
-    tagSelect.isEnabled = true
-
-    val autocomplete = ArrayAdapter(context, android.R.layout.simple_expandable_list_item_1, allTags)
-    // the cast to ArrayList is kinda icky but so long as the API response is OK, it should work
-    tagSelect.threshold = 1
-    tagSelect.setAdapter(autocomplete)
-    tagSelect.setOnFocusChangeListener { v, hasFocus ->
-      if (!hasFocus) {
-        Util.hideSoftKeyboard(view, context)
-      } else {
-        tagSelect.showDropDown() // make sure the suggestions show even if no characters have been entered
-      }
+    companion object {
+        fun newInstance(): TapFragment {
+            return TapFragment()
+        }
     }
 
-    check_in_out_select.setOnCheckedChangeListener { _, isChecked ->
-      check_in_out_select.text = when (isChecked) {
-        true -> getString(R.string.switch_check_in)
-        false -> getString(R.string.switch_check_out)
-      }
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_tap, container, false)
     }
 
-    loadNFC(view)
-  }
+    override fun onResume() {
+        super.onResume()
 
-  fun loadNFC(view: View) {
+        // in case NFC becomes enabled in settings
+        loadNFC()
+    }
 
-    val nfcAdapter = NfcAdapter.getDefaultAdapter(context)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        Log.i("checkin-tap", "inside onviewcreated")
+        val tagSelect: AutoCompleteTextView = checkin_tag
+        val prevTag = tagSelect.text
+        tagSelect.setText("Updating tags list...")
+        tagSelect.isEnabled = false
 
-    val nfcInfo = view.findViewById<TextView>(R.id.nfcInstructions)
-    val nfcProgressBar = view.findViewById<ProgressBar>(R.id.wait_for_badge_tap)
-    val warningIcon = view.findViewById<ImageView>(R.id.nfc_error)
-    val nfcEnableButton = view.findViewById<Button>(R.id.enable_nfc_button)
+        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        var allTags = runBlocking { API.getTags(preferences) } // TODO: this seems to delay showing this screen, so check that out
+        val currentCheckinTags = runBlocking { API.getTags(preferences, true) }
 
-    if (nfcAdapter == null) {
-
-      nfcInfo.text = getString(R.string.nfc_unsupported_device)
-
-      nfcProgressBar.visibility = View.GONE
-      warningIcon.visibility = View.VISIBLE
-      nfcEnableButton.visibility = View.GONE
-
-    } else if (!nfcAdapter.isEnabled) {
-
-      nfcInfo.text = getString(R.string.nfc_disabled)
-
-      nfcProgressBar.visibility = View.GONE
-      warningIcon.visibility = View.VISIBLE
-      nfcEnableButton.visibility = View.VISIBLE
-
-      nfcEnableButton.setOnClickListener(this)
-
-    } else {
-
-      nfcInfo.text = getString(R.string.nfc_ready)
-
-      nfcProgressBar.visibility = View.VISIBLE
-      warningIcon.visibility = View.GONE
-      nfcEnableButton.visibility = View.GONE
-
-      // prevents being called multiple times if it is already enabled in reader mode
-      if (nfcIsLoaded) {
-        return
-      }
-
-      val uuidRegex = Regex("[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}")
-      val tagSelect: AutoCompleteTextView = checkin_tag
-      val preferences = PreferenceManager.getDefaultSharedPreferences(activity)
-
-      nfcIsLoaded = true
-
-      nfcAdapter.enableReaderMode(activity, { tag: Tag ->
-        if (waitingForTag) {
-          waitingForTag = false
-          // get the latest read tag
-          val ndef = Ndef.get(tag)
-          val record: NdefRecord? = try {
-            ndef.connect()
-            val message = ndef.ndefMessage
-            message.records[0]
-          } catch (e: Throwable) {
-            Log.i(TAG, "" + e.printStackTrace())
-            null
-          } finally {
-            try {
-              ndef.close()
-            } catch (e: Throwable) {
-              e.printStackTrace()
+        allTags = allTags as ArrayList<String>
+        allTags.sortWith(kotlin.Comparator { t1, t2 ->
+            val t1SortVal = when (currentCheckinTags?.contains(t1)) {
+                true -> -1
+                else -> 0
             }
-          }
-
-          val id: Uri? = record?.toUri()
-          Log.i(TAG, id.toString())
-          if (id?.host == "live.hack.gt" && uuidRegex.containsMatchIn(id.getQueryParameter("user").orEmpty())) {
-            val uuid = id.getQueryParameter("user").orEmpty()
-            Log.i(TAG, "this valid id is " + uuid)
-
-            val tagName = tagSelect.text.trim().toString()
-            val doCheckIn = check_in_out_select.isChecked
-            // check in/out the user
-
-            val userInfo = runBlocking { API.getUserById(preferences, uuid)!!.user().fragments().userFragment() }
-            val currentTags = runBlocking { API.getTagsForUser(preferences, uuid) }
-            val newTags = when (doCheckIn) {
-              true -> runBlocking { API.checkInTag(preferences, uuid, tagName) }
-              else -> runBlocking { API.checkOutTag(preferences, uuid, tagName) }
+            val t2SortVal = when (currentCheckinTags?.contains(t2)) {
+                true -> -1
+                else -> 0
             }
+            t1SortVal - t2SortVal
+        })
+        Log.i(TAG, "Contents of sorted allTags: " + allTags)
 
-            val checkInData = CheckInData(userInfo, currentTags, newTags!!)
+        tagSelect.text = prevTag
+        tagSelect.isEnabled = true
 
-            drawCheckInFinish(checkInData, tagName)
-
-            Log.i(TAG, checkInData.userInfo.toString())
-            Log.i(TAG, checkInData.currentTags.toString())
-            Log.i(TAG, checkInData.newTags.toString())
-          } else {
-            if (id == null) {
-              Log.i(TAG, "this tag's data is null: " + id)
-              displayMessageAndReset(false, getString(R.string.badge_data_null), 5000)
+        val autocomplete = ArrayAdapter(context, android.R.layout.simple_expandable_list_item_1, allTags)
+        // the cast to ArrayList is kinda icky but so long as the API response is OK, it should work
+        tagSelect.threshold = 1
+        tagSelect.setAdapter(autocomplete)
+        tagSelect.setOnFocusChangeListener { v, hasFocus ->
+            if (!hasFocus) {
+                Util.hideSoftKeyboard(view, context!!)
             } else {
-              Log.i(TAG, "this tag's data is formatted incorrectly: " + id)
-              displayMessageAndReset(false, getString(R.string.invalid_badge_id), 6000)
+                tagSelect.showDropDown() // make sure the suggestions show even if no characters have been entered
             }
-          }
+        }
+
+        check_in_out_select.setOnCheckedChangeListener { _, isChecked ->
+            check_in_out_select.text = when (isChecked) {
+                true -> getString(R.string.switch_check_in)
+                false -> getString(R.string.switch_check_out)
+            }
+        }
+
+        nfcHandler.activity = activity
+        nfcHandler.context = context
+        nfcHandler.callback = NfcAdapter.ReaderCallback { tag: Tag ->
+            val uuidRegex = Regex("[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}")
+            val tagSelect: AutoCompleteTextView = checkin_tag
+            val preferences = PreferenceManager.getDefaultSharedPreferences(activity)
+
+            if (waitingForTag) {
+                waitingForTag = false
+                // get the latest read tag
+                val ndef = Ndef.get(tag)
+                val record: NdefRecord? = try {
+                    ndef.connect()
+                    val message = ndef.ndefMessage
+                    message.records[0]
+                } catch (e: Throwable) {
+                    Log.i(TAG, "" + e.printStackTrace())
+                    null
+                } finally {
+                    try {
+                        ndef.close()
+                    } catch (e: Throwable) {
+                        e.printStackTrace()
+                    }
+                }
+
+                val id: Uri? = record?.toUri()
+                Log.i(TAG, id.toString())
+                if (id?.host == "live.hack.gt" && uuidRegex.containsMatchIn(id.getQueryParameter("user").orEmpty())) {
+                    val uuid = id.getQueryParameter("user").orEmpty()
+                    Log.i(TAG, "this valid id is " + uuid)
+
+                    val tagName = tagSelect.text.trim().toString()
+                    val doCheckIn = check_in_out_select.isChecked
+                    // check in/out the user
+
+                    val userInfo = runBlocking { API.getUserById(preferences, uuid)!!.user().fragments().userFragment() }
+                    val currentTags = runBlocking { API.getTagsForUser(preferences, uuid) }
+                    val newTags = when (doCheckIn) {
+                        true -> runBlocking { API.checkInTag(preferences, uuid, tagName) }
+                        else -> runBlocking { API.checkOutTag(preferences, uuid, tagName) }
+                    }
+
+                    val checkInData = CheckInData(userInfo, currentTags, newTags!!)
+
+                    drawCheckInFinish(checkInData, tagName)
+
+                    Log.i(TAG, checkInData.userInfo.toString())
+                    Log.i(TAG, checkInData.currentTags.toString())
+                    Log.i(TAG, checkInData.newTags.toString())
+                } else {
+                    if (id == null) {
+                        Log.i(TAG, "this tag's data is null: " + id)
+                        displayMessageAndReset(false, getString(R.string.badge_data_null), 5000)
+                    } else {
+                        Log.i(TAG, "this tag's data is formatted incorrectly: " + id)
+                        displayMessageAndReset(false, getString(R.string.invalid_badge_id), 6000)
+                    }
+                }
+
+            }
 
         }
 
-      }, READER_FLAGS, null)
+        loadNFC()
     }
 
-  }
-
-  override fun onClick(view: View?) {
-    if (view == null) {
-      return
+    fun loadNFC() {
+        nfcHandler.loadNFC(nfcInstructions, wait_for_badge_tap, nfc_error, enable_nfc_button)
     }
 
-    if (view!!.id == R.id.enable_nfc_button) {
-      startActivity(Intent(Settings.ACTION_NFC_SETTINGS))
-    }
-  }
+    fun drawCheckInFinish(checkInData: CheckInData, tagName: String) {
+        val waitingForBadge = wait_for_badge_tap
+        val userName = track_name
+        val userBranch = track_type
+        val userShirtSize = track_tshirt_size
+        val userDietaryRestrictions = track_dietary_restrictions
 
-  fun drawCheckInFinish(checkInData: CheckInData, tagName: String) {
-    val waitingForBadge = wait_for_badge_tap
-    val userName = track_name
-    val userBranch = track_type
-    val userShirtSize = track_tshirt_size
-    val userDietaryRestrictions = track_dietary_restrictions
+        val userInfo = checkInData.userInfo
+        var userShirtSizeVal: String? = ""
+        var userDietaryRestrictionsVal: String? = ""
+        if (userInfo != null) {
 
-    val userInfo = checkInData.userInfo
-    var userShirtSizeVal: String? = ""
-    var userDietaryRestrictionsVal: String? = ""
-    if (userInfo != null) {
+            userInfo.questions.forEach { question: UserFragment.Question? ->
+                if (question?.name.equals("tshirt-size")) {
+                    userShirtSizeVal = question?.value
+                } else if (question?.name.equals("dietary-restrictions")) {
+                    userDietaryRestrictionsVal = question?.values.toString()
+                }
+            }
 
-      userInfo.questions.forEach { question: UserFragment.Question? ->
-        if (question?.name.equals("tshirt-size")) {
-          userShirtSizeVal = question?.value
-        } else if (question?.name.equals("dietary-restrictions")) {
-          userDietaryRestrictionsVal = question?.values.toString()
+            Log.i(TAG, "" + checkInData.currentTags)
+            var prevTagState: Boolean? = null
+            var newTagState: Boolean? = null
+            var prevTagTime: String? = null
+            var unseenTag = false
+            if (checkInData.currentTags!![tagName] != null) {
+                prevTagState = checkInData.currentTags[tagName]!!.checked_in
+                newTagState = checkInData.newTags[tagName]!!.checked_in
+            } else {
+                unseenTag = true
+            }
+
+
+            Log.i(TAG, "prevTagState: " + prevTagState)
+            Log.i(TAG, "newTagState: " + newTagState)
+
+            val validOperation = (prevTagState != newTagState && !unseenTag)
+                    || (newTagState == null && check_in_out_select.isChecked)
+
+            activity?.runOnUiThread {
+                userName.text = userInfo.name
+                if (userInfo.application != null) {
+                    userBranch.text = userInfo.application.type
+                }
+
+                userShirtSize.text = userShirtSizeVal
+                try {
+                    userDietaryRestrictions.text = userDietaryRestrictionsVal?.substring(1)?.dropLast(1)
+                } catch (e: StringIndexOutOfBoundsException) {
+                    userDietaryRestrictions.text = ""
+                }
+
+                waitingForBadge.visibility = View.GONE
+                nfcInstructions.visibility = View.GONE
+            }
+
+            if (validOperation) {
+                displayMessageAndReset(true, "", 1000)
+            } else {
+                if (prevTagState != null && prevTagState) { // indicates checkin/out state
+                    displayMessageAndReset(false, getString(R.string.user_already_checked_in), 5000)
+                } else if (newTagState == null && !check_in_out_select.isChecked) {
+                    displayMessageAndReset(false, getString(R.string.cannot_checkout_not_checked_in), 5000)
+                } else {
+                    displayMessageAndReset(false, getString(R.string.user_already_checked_out), 5000)
+                }
+            }
+        } else { // checkInData is null, ie invalid user
+            displayMessageAndReset(false, getString(R.string.invalid_badge_id), 5000)
         }
-      }
-
-      Log.i(TAG, "" + checkInData.currentTags)
-      var prevTagState: Boolean? = null
-      var newTagState: Boolean? = null
-      var prevTagTime: String? = null
-      var unseenTag = false
-      if (checkInData.currentTags!![tagName] != null) {
-        prevTagState = checkInData.currentTags[tagName]!!.checked_in
-        newTagState = checkInData.newTags[tagName]!!.checked_in
-      } else {
-        unseenTag = true
-      }
-
-
-      Log.i(TAG, "prevTagState: " + prevTagState)
-      Log.i(TAG, "newTagState: " + newTagState)
-
-      val validOperation = (prevTagState != newTagState && !unseenTag)
-          || (newTagState == null && check_in_out_select.isChecked)
-
-      activity?.runOnUiThread {
-        userName.text = userInfo.name
-        if (userInfo.application != null) {
-          userBranch.text = userInfo.application.type
-        }
-
-        userShirtSize.text = userShirtSizeVal
-        try {
-          userDietaryRestrictions.text = userDietaryRestrictionsVal?.substring(1)?.dropLast(1)
-        } catch (e : StringIndexOutOfBoundsException) {
-          userDietaryRestrictions.text = ""
-        }
-
-        waitingForBadge.visibility = View.GONE
-      }
-
-      if (validOperation) {
-        displayMessageAndReset(true, "", 1000)
-      } else {
-        if (prevTagState != null && prevTagState) { // indicates checkin/out state
-          displayMessageAndReset(false, getString(R.string.user_already_checked_in), 5000)
-        } else if (newTagState == null && !check_in_out_select.isChecked) {
-          displayMessageAndReset(false, getString(R.string.cannot_checkout_not_checked_in), 5000)
-        } else {
-          displayMessageAndReset(false, getString(R.string.user_already_checked_out), 5000)
-        }
-      }
-    } else { // checkInData is null, ie invalid user
-      displayMessageAndReset(false, getString(R.string.invalid_badge_id), 5000)
     }
-  }
 
-  fun displayMessageAndReset(validTag: Boolean, message: String, duration: Long) {
-    activity?.runOnUiThread {
-      val waitingForBadge = wait_for_badge_tap
-      val badgeTapped = badge_tapped
+    fun displayMessageAndReset(validTag: Boolean, message: String, duration: Long) {
+        activity?.runOnUiThread {
+            val waitingForBadge = wait_for_badge_tap
+            val badgeTapped = badge_tapped
 
-      waitingForBadge.visibility = View.GONE
+            waitingForBadge.visibility = View.GONE
+            nfcInstructions.visibility = View.GONE
 
-      if (validTag) {
-        badgeTapped.visibility = View.VISIBLE
-      } else {
-        val toneGen1 = ToneGenerator(AudioManager.STREAM_MUSIC, 100)
-        toneGen1.startTone(ToneGenerator.TONE_CDMA_EMERGENCY_RINGBACK, 500)
+            if (validTag) {
+                badgeTapped.visibility = View.VISIBLE
+            } else {
+                val toneGen1 = ToneGenerator(AudioManager.STREAM_MUSIC, 100)
+                toneGen1.startTone(ToneGenerator.TONE_CDMA_EMERGENCY_RINGBACK, 500)
 
-        invalid_tap_msg.text = message
-        invalid_tap.visibility = View.VISIBLE
-        invalid_tap_msg.visibility = View.VISIBLE
-      }
+                invalid_tap_msg.text = message
+                invalid_tap.visibility = View.VISIBLE
+                invalid_tap_msg.visibility = View.VISIBLE
+            }
 
-      Handler().postDelayed({
-        waitingForBadge.visibility = View.VISIBLE
-        badgeTapped.visibility = View.GONE
-        invalid_tap.visibility = View.GONE
-        invalid_tap_msg.visibility = View.GONE
-        waitingForTag = true
-      }, duration)
+            Handler().postDelayed({
+                waitingForBadge.visibility = View.VISIBLE
+                nfcInstructions.visibility = View.VISIBLE
+
+                badgeTapped.visibility = View.GONE
+                invalid_tap.visibility = View.GONE
+                invalid_tap_msg.visibility = View.GONE
+
+                waitingForTag = true
+            }, duration)
+        }
     }
-  }
 
 
-
-  data class CheckInData(val userInfo: UserFragment?, val currentTags: HashMap<String, TagFragment>?, val newTags: HashMap<String, TagFragment>)
+    data class CheckInData(val userInfo: UserFragment?, val currentTags: HashMap<String, TagFragment>?, val newTags: HashMap<String, TagFragment>)
 }

--- a/app/src/main/java/gt/hack/nfc/fragment/TapFragment.kt
+++ b/app/src/main/java/gt/hack/nfc/fragment/TapFragment.kt
@@ -103,7 +103,7 @@ class TapFragment : Fragment() {
 
     if (nfc == null) {
       // if device does not support NFC provide dialog instead of just crashing
-      showAlert("This device does not support NFC.", "Badges cannot be read or written using this device.")
+      Util.showWarning(context, R.string.nfc_not_supported_device_title, R.string.nfc_not_supported__device_message)
       return
     }
 
@@ -279,22 +279,7 @@ class TapFragment : Fragment() {
     }
   }
 
-  fun showAlert(title: String, message: CharSequence) {
-    val builder: AlertDialog.Builder
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      builder = AlertDialog.Builder(context, android.R.style.Theme_Material_Dialog_Alert)
-    } else {
-      builder = AlertDialog.Builder(context)
-    }
-
-
-    builder.setTitle(title)
-        .setMessage(message)
-        .setNeutralButton(android.R.string.ok, OnClickListener({ dialog, which -> }))
-        .setIcon(android.R.drawable.ic_dialog_alert)
-        .show()
-  }
 
   data class CheckInData(val userInfo: UserFragment?, val currentTags: HashMap<String, TagFragment>?, val newTags: HashMap<String, TagFragment>)
 }

--- a/app/src/main/java/gt/hack/nfc/fragment/TapFragment.kt
+++ b/app/src/main/java/gt/hack/nfc/fragment/TapFragment.kt
@@ -29,7 +29,7 @@ import gt.hack.nfc.util.API
 import gt.hack.nfc.util.Util
 
 import kotlinx.android.synthetic.main.fragment_tap.*
-import kotlinx.coroutines.experimental.*
+import kotlinx.coroutines.runBlocking
 import kotlin.collections.ArrayList
 
 

--- a/app/src/main/java/gt/hack/nfc/util/API.kt
+++ b/app/src/main/java/gt/hack/nfc/util/API.kt
@@ -23,7 +23,9 @@ import gt.hack.nfc.fragment.UserFragment
 import okhttp3.FormBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import kotlin.coroutines.experimental.suspendCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 
 object API {
     @Throws(IOException::class)

--- a/app/src/main/java/gt/hack/nfc/util/CheckInAsyncTask.kt
+++ b/app/src/main/java/gt/hack/nfc/util/CheckInAsyncTask.kt
@@ -12,7 +12,7 @@ import java.util.HashMap
 
 import gt.hack.nfc.R
 import gt.hack.nfc.fragment.TagFragment
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 
 
 /**

--- a/app/src/main/java/gt/hack/nfc/util/NFCHandler.kt
+++ b/app/src/main/java/gt/hack/nfc/util/NFCHandler.kt
@@ -1,0 +1,70 @@
+package gt.hack.nfc.util
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.nfc.NfcAdapter
+import android.provider.Settings
+import android.view.View
+import android.widget.*
+import gt.hack.nfc.R
+import gt.hack.nfc.fragment.CheckinFlowFragment
+
+class NFCHandler: View.OnClickListener {
+
+    var nfcIsLoaded = false
+    var callback: NfcAdapter.ReaderCallback? = null
+    var activity: Activity? = null
+    var context: Context? = null
+
+    // given UI elements, will configure the UI and run the required functions for hiding/showing errors and buttons
+    fun loadNFC(info: TextView, progressBar: ProgressBar, warningIcon: ImageView, enableButton: Button) {
+        val nfcAdapter = NfcAdapter.getDefaultAdapter(context)
+
+        if (nfcAdapter == null) {
+
+            info.text = context?.getString(R.string.nfc_unsupported_device)
+
+            progressBar.visibility = View.GONE
+            warningIcon.visibility = View.VISIBLE
+            enableButton.visibility = View.GONE
+
+        } else if (!nfcAdapter.isEnabled) {
+
+            info.text = context?.getString(R.string.nfc_disabled)
+
+            progressBar.visibility = View.GONE
+            warningIcon.visibility = View.VISIBLE
+            enableButton.visibility = View.VISIBLE
+
+            enableButton.setOnClickListener(this)
+
+        } else {
+
+            info.text = context?.getString(R.string.nfc_ready)
+
+            progressBar.visibility = View.VISIBLE
+            warningIcon.visibility = View.GONE
+            enableButton.visibility = View.GONE
+
+            if (nfcIsLoaded) {
+                return
+            }
+
+            nfcIsLoaded = true
+
+            nfcAdapter.enableReaderMode(activity, callback, CheckinFlowFragment.READER_FLAGS, null)
+        }
+    }
+
+    override fun onClick(view: View?) {
+        if (view == null) {
+            return
+        }
+
+        if (view.id == R.id.enable_nfc_button) {
+            context?.startActivity(Intent(Settings.ACTION_NFC_SETTINGS))
+        }
+    }
+
+}

--- a/app/src/main/java/gt/hack/nfc/util/TagAsyncTask.kt
+++ b/app/src/main/java/gt/hack/nfc/util/TagAsyncTask.kt
@@ -12,7 +12,7 @@ import java.util.HashMap
 
 import gt.hack.nfc.R
 import gt.hack.nfc.fragment.TagFragment
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 
 
 /**

--- a/app/src/main/java/gt/hack/nfc/util/Util.java
+++ b/app/src/main/java/gt/hack/nfc/util/Util.java
@@ -2,7 +2,9 @@ package gt.hack.nfc.util;
 
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Context;
+import android.os.Build;
 import android.support.design.widget.BaseTransientBottomBar;
 import android.support.design.widget.Snackbar;
 import android.util.Log;
@@ -12,8 +14,6 @@ import android.view.inputmethod.InputMethodManager;
 
 import java.lang.reflect.Field;
 import java.util.List;
-
-import gt.hack.nfc.fragment.UserFragment;
 
 public class Util {
     public static final String DEFAULT_SERVER = "https://checkin.hack.gt";
@@ -27,6 +27,22 @@ public class Util {
             }
         }
         return null;
+    }
+
+    public static void showWarning(Context context, int title, int message) {
+        AlertDialog.Builder builder;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            builder = new AlertDialog.Builder(context, android.R.style.Theme_Material_Dialog_Alert);
+        } else {
+            builder = new AlertDialog.Builder(context);
+        }
+
+        builder.setTitle(title)
+                .setMessage(message)
+                .setNeutralButton(android.R.string.ok, null)
+                .setIcon(android.R.drawable.ic_dialog_alert)
+                .show();
     }
 
     public static Snackbar makeSnackbar(View view, int resId, int duration) {

--- a/app/src/main/java/gt/hack/nfc/util/Util.java
+++ b/app/src/main/java/gt/hack/nfc/util/Util.java
@@ -15,6 +15,8 @@ import android.view.inputmethod.InputMethodManager;
 import java.lang.reflect.Field;
 import java.util.List;
 
+import gt.hack.nfc.fragment.UserFragment;
+
 public class Util {
     public static final String DEFAULT_SERVER = "https://checkin.hack.gt";
     // Whether to make the tag read-only by default in production

--- a/app/src/main/res/drawable/warning.xml
+++ b/app/src/main/res/drawable/warning.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#FDD835" android:pathData="M11,15H13V17H11V15M11,7H13V13H11V7M12,2C6.47,2 2,6.5 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20Z" />
+</vector>

--- a/app/src/main/res/layout/fragment_checkin_confirm.xml
+++ b/app/src/main/res/layout/fragment_checkin_confirm.xml
@@ -101,22 +101,24 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:paddingTop="16dp">
+                <ProgressBar
+                    android:id="@+id/wait_for_badge_tap"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="end"
+                    android:gravity="center_horizontal"
+                    android:layout_marginTop="24dp" />
+
+
                 <TextView
                     android:id="@+id/nfcInstructions"
                     android:layout_width="match_parent"
                     android:gravity="center_horizontal"
                     android:layout_height="wrap_content"
-                    android:text="Waiting for badge..."
+                    android:text="@string/nfc_ready"
                     android:layout_gravity="center_vertical"
-                    android:textSize="24sp"
-                    android:paddingRight="16dp"/>
-                <ProgressBar
-                    android:id="@+id/waitForBadge"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:gravity="center_horizontal"
-                    android:layout_gravity="end"
-                    android:paddingTop="16dp"/>
+                    android:textSize="24sp" />
+
                 <ImageView
                     android:id="@+id/badgeWritten"
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_checkin_confirm.xml
+++ b/app/src/main/res/layout/fragment_checkin_confirm.xml
@@ -101,6 +101,17 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:paddingTop="16dp">
+
+                <ImageView
+                    android:id="@+id/nfc_error"
+                    android:layout_width="match_parent"
+                    android:layout_height="64dp"
+                    android:gravity="center_horizontal"
+                    android:layout_gravity="end"
+                    android:layout_marginTop="16dp"
+                    android:src="@drawable/warning"
+                    android:visibility="gone" />
+
                 <ProgressBar
                     android:id="@+id/wait_for_badge_tap"
                     android:layout_width="match_parent"
@@ -118,6 +129,29 @@
                     android:text="@string/nfc_ready"
                     android:layout_gravity="center_vertical"
                     android:textSize="24sp" />
+
+                <android.support.v7.widget.AppCompatButton
+                    android:id="@+id/enable_nfc_button"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginBottom="24dp"
+                    android:textColor="@color/white"
+                    android:background="@color/primaryColor"
+                    android:padding="12dp"
+                    android:visibility="gone"
+                    android:text="Enable NFC" />
+
+                <ImageView
+                    android:id="@+id/badge_tapped"
+                    android:layout_width="match_parent"
+                    android:layout_height="64dp"
+                    android:tint="@color/success"
+                    android:visibility="gone"
+                    android:gravity="center_horizontal"
+                    android:layout_gravity="end"
+                    android:paddingTop="16dp"
+                    android:src="@drawable/check" />
 
                 <ImageView
                     android:id="@+id/badgeWritten"

--- a/app/src/main/res/layout/fragment_tap.xml
+++ b/app/src/main/res/layout/fragment_tap.xml
@@ -113,13 +113,46 @@
                 android:textColor="@color/secondaryTextColor"
                 android:textSize="20dp" />
 
+            <ImageView
+                android:id="@+id/nfc_error"
+                android:layout_width="match_parent"
+                android:layout_height="64dp"
+                android:gravity="center_horizontal"
+                android:layout_gravity="end"
+                android:layout_marginTop="16dp"
+                android:src="@drawable/warning"
+                android:visibility="gone"
+                />
+
             <ProgressBar
                 android:id="@+id/wait_for_badge_tap"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
                 android:gravity="center_horizontal"
-                android:paddingTop="20dp" />
+                android:layout_marginTop="24dp" />
+
+
+            <TextView
+                android:id="@+id/nfcInstructions"
+                android:layout_width="match_parent"
+                android:gravity="center_horizontal"
+                android:layout_height="wrap_content"
+                android:text="@string/nfc_ready"
+                android:layout_gravity="center_vertical"
+                android:textSize="24sp" />
+
+            <android.support.v7.widget.AppCompatButton
+                android:id="@+id/enable_nfc_button"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="24dp"
+                android:textColor="@color/white"
+                android:background="@color/primaryColor"
+                android:padding="12dp"
+                android:visibility="gone"
+                android:text="Enable NFC" />
 
             <ImageView
                 android:id="@+id/badge_tapped"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="user_already_checked_in">User already checked in for this tag</string>
     <string name="user_already_checked_out">User already checked out for this tag</string>
     <string name="cannot_checkout_not_checked_in">Cannot checkout - user is not checked in</string>
-    <string name="nfc_not_supported_device_title">Device does not support NFC</string>
-    <string name="nfc_not_supported__device_message">Badges cannot be read or written using this device.</string>
+    <string name="nfc_unsupported_device">NFC Unsupported Device</string>
+    <string name="nfc_disabled">NFC Disabled</string>
+    <string name="nfc_ready">Waiting for badge...</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,4 +42,6 @@
     <string name="user_already_checked_in">User already checked in for this tag</string>
     <string name="user_already_checked_out">User already checked out for this tag</string>
     <string name="cannot_checkout_not_checked_in">Cannot checkout - user is not checked in</string>
+    <string name="nfc_not_supported_device_title">This device does not support NFC.</string>
+    <string name="nfc_not_supported__device_message">Badges cannot be read or written using this device.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,6 @@
     <string name="user_already_checked_in">User already checked in for this tag</string>
     <string name="user_already_checked_out">User already checked out for this tag</string>
     <string name="cannot_checkout_not_checked_in">Cannot checkout - user is not checked in</string>
-    <string name="nfc_not_supported_device_title">This device does not support NFC.</string>
+    <string name="nfc_not_supported_device_title">Device does not support NFC</string>
     <string name="nfc_not_supported__device_message">Badges cannot be read or written using this device.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="user_already_checked_in">User already checked in for this tag</string>
     <string name="user_already_checked_out">User already checked out for this tag</string>
     <string name="cannot_checkout_not_checked_in">Cannot checkout - user is not checked in</string>
-    <string name="nfc_unsupported_device">NFC Unsupported Device</string>
-    <string name="nfc_disabled">NFC Disabled</string>
+    <string name="nfc_unsupported_device">Device does not support NFC</string>
+    <string name="nfc_disabled">NFC is currently disabled</string>
     <string name="nfc_ready">Waiting for badge...</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.20'
     repositories {
         jcenter()
         maven { url 'https://jitpack.io' }
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath 'com.apollographql.apollo:apollo-gradle-plugin:1.0.0-alpha2'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 11 15:02:55 EDT 2018
+#Sun Feb 03 16:42:37 EST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
- Fixes searches being duplicated within search fragment
- Adds a message when NFC is unsupported / disabled on the device to prevent crashes/confusion
- Adds convenient button to take user to NFC settings if disabled
- Adds "Waiting for badge..." on track event screen

<img width="266" alt="screen shot 2019-02-08 at 5 15 03 pm" src="https://user-images.githubusercontent.com/16421258/52510535-5458ba80-2bca-11e9-8625-9d6a47d39906.png">
<img width="270" alt="screen shot 2019-02-08 at 5 17 06 pm" src="https://user-images.githubusercontent.com/16421258/52510545-5a4e9b80-2bca-11e9-97fc-12558a704bb1.png">
<img width="270" alt="screen shot 2019-02-08 at 5 15 42 pm" src="https://user-images.githubusercontent.com/16421258/52512173-7dc91480-2bd1-11e9-980f-8c2a5bba78e1.png">

closes #26 
closes #16 
closes #17